### PR TITLE
configure maven deploy

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,14 @@
+VERSION_NAME=1.0.0
+VERSION_CODE=1
+GROUP=jp.mixi
+
+POM_DESCRIPTION=mixi API SDK for Android
+POM_URL=https://github.com/mixi-inc/mixi-API-SDK-for-Android
+POM_SCM_URL=https://github.com/mixi-inc/mixi-API-SDK-for-Android
+POM_SCM_CONNECTION=scm:git@github.com:mixi-inc/mixi-API-SDK-for-Android.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:mixi-inc/mixi-API-SDK-for-Android.git
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+POM_DEVELOPER_ID=mixi
+POM_DEVELOPER_NAME=mixi,Inc.

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
 
 android {
     compileSdkVersion 22

--- a/lib/gradle.properties
+++ b/lib/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=mixi API SDK for Android
+POM_ARTIFACT_ID=mixi-api-sdk-android
+POM_PACKAGING=aar


### PR DESCRIPTION
デプロイ関係の設定ファイルです。

maven centralへのデプロイは完了しています

```
compile 'jp.mixi:mixi-api-sdk-android:1.0.0'
```

でインポートできます
